### PR TITLE
Fix issues with the Notice of Departure feature

### DIFF
--- a/src/main/kotlin/dev/vxrp/bot/commands/handler/bot/template/templates/NoticeOfDepartureTemplate.kt
+++ b/src/main/kotlin/dev/vxrp/bot/commands/handler/bot/template/templates/NoticeOfDepartureTemplate.kt
@@ -5,14 +5,15 @@ import dev.minn.jda.ktx.messages.send
 import dev.vxrp.configuration.data.Config
 import dev.vxrp.configuration.data.Translation
 import net.dv8tion.jda.api.entities.emoji.Emoji
+import dev.vxrp.util.color.ColorTool
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
 import net.dv8tion.jda.api.interactions.components.buttons.Button
 
 class NoticeOfDepartureTemplate(val config: Config, val translation: Translation) {
     fun pasteTemplate(event: SlashCommandInteractionEvent) {
         val embed = Embed {
-            title = translation.noticeOfDeparture.embedTemplateTitle
-            description = translation.noticeOfDeparture.embedTemplateBody
+            title = ColorTool().useCustomColorCodes(translation.noticeOfDeparture.embedTemplateTitle)
+            description = ColorTool().useCustomColorCodes(translation.noticeOfDeparture.embedTemplateBody)
         }
 
         event.channel.send("", listOf(embed)).setActionRow(

--- a/src/main/kotlin/dev/vxrp/bot/events/modals/NoticeOfDepartureModals.kt
+++ b/src/main/kotlin/dev/vxrp/bot/events/modals/NoticeOfDepartureModals.kt
@@ -9,6 +9,7 @@ import dev.vxrp.configuration.data.Translation
 import dev.vxrp.util.color.ColorTool
 import net.dv8tion.jda.api.events.interaction.ModalInteractionEvent
 import java.time.LocalDate
+import java.time.format.DateTimeFormatter
 import java.time.format.DateTimeParseException
 
 class NoticeOfDepartureModals(val event: ModalInteractionEvent, val config: Config, val translation: Translation) {
@@ -18,7 +19,8 @@ class NoticeOfDepartureModals(val event: ModalInteractionEvent, val config: Conf
             val reason = event.values[1].asString
 
             try {
-                LocalDate.parse(date)
+                val formatter = DateTimeFormatter.ofPattern("dd.MM.yyyy")
+                LocalDate.parse(date, formatter)
             } catch (_: DateTimeParseException) {
                 event.reply_("Please enter a valid date format to proceed").queue()
                 return

--- a/src/main/kotlin/dev/vxrp/bot/events/modals/NoticeOfDepartureModals.kt
+++ b/src/main/kotlin/dev/vxrp/bot/events/modals/NoticeOfDepartureModals.kt
@@ -2,6 +2,7 @@ package dev.vxrp.bot.events.modals
 
 import dev.minn.jda.ktx.messages.Embed
 import dev.minn.jda.ktx.messages.reply_
+import dev.minn.jda.ktx.messages.send
 import dev.vxrp.bot.noticeofdeparture.NoticeOfDepartureManager
 import dev.vxrp.bot.noticeofdeparture.handler.NoticeOfDepartureMessageHandler
 import dev.vxrp.configuration.data.Config
@@ -34,7 +35,7 @@ class NoticeOfDepartureModals(val event: ModalInteractionEvent, val config: Conf
                 description = ColorTool().useCustomColorCodes(translation.noticeOfDeparture.embedDecisionSentBody)
             }
 
-            event.reply_("", listOf(embed)).setEphemeral(true).queue()
+            event.hook.send("", listOf(embed)).setEphemeral(true).queue()
         }
 
         if (event.modalId.startsWith("notice_of_departure_reason_action_ACCEPTING")) {

--- a/src/main/kotlin/dev/vxrp/bot/events/modals/NoticeOfDepartureModals.kt
+++ b/src/main/kotlin/dev/vxrp/bot/events/modals/NoticeOfDepartureModals.kt
@@ -2,7 +2,6 @@ package dev.vxrp.bot.events.modals
 
 import dev.minn.jda.ktx.messages.Embed
 import dev.minn.jda.ktx.messages.reply_
-import dev.minn.jda.ktx.messages.send
 import dev.vxrp.bot.noticeofdeparture.NoticeOfDepartureManager
 import dev.vxrp.bot.noticeofdeparture.handler.NoticeOfDepartureMessageHandler
 import dev.vxrp.configuration.data.Config
@@ -20,17 +19,16 @@ class NoticeOfDepartureModals(val event: ModalInteractionEvent, val config: Conf
             val reason = event.values[1].asString
             val formatter = DateTimeFormatter.ofPattern("dd.MM.yyyy")
 
-            try {
+            val parsedDate = try {
                 LocalDate.parse(date, formatter)
             } catch (_: DateTimeParseException) {
-                event.hook.send("Please enter a valid date format to proceed").queue()
+                event.reply_("Please enter a valid date format to proceed").queue()
                 return
             }
 
             val currentDate = LocalDate.now()
-            val parsedDate = LocalDate.parse(date, formatter)
             if (parsedDate.isBefore(currentDate)) {
-                event.hook.send("Please enter a date in the future to proceed").queue()
+                event.reply_("Please enter a date in the future to proceed").queue()
                 return
             }
 
@@ -42,7 +40,7 @@ class NoticeOfDepartureModals(val event: ModalInteractionEvent, val config: Conf
                 description = ColorTool().useCustomColorCodes(translation.noticeOfDeparture.embedDecisionSentBody)
             }
 
-            event.hook.send("", listOf(embed)).setEphemeral(true).queue()
+            event.reply_("", listOf(embed)).setEphemeral(true).queue()
         }
 
         if (event.modalId.startsWith("notice_of_departure_reason_action_ACCEPTING")) {

--- a/src/main/kotlin/dev/vxrp/bot/events/modals/NoticeOfDepartureModals.kt
+++ b/src/main/kotlin/dev/vxrp/bot/events/modals/NoticeOfDepartureModals.kt
@@ -27,6 +27,15 @@ class NoticeOfDepartureModals(val event: ModalInteractionEvent, val config: Conf
                 return
             }
 
+            // Get current date a day ago to allow for the current day to be selected and to allow different timezones
+            // to be taken into account
+            val currentDate = LocalDate.now().minusDays(1)
+            val parsedDate = LocalDate.parse(date, DateTimeFormatter.ofPattern("dd.MM.yyyy"))
+            if (parsedDate.isBefore(currentDate)) {
+                event.hook.send("Please enter a date in the future to proceed").queue()
+                return
+            }
+
             NoticeOfDepartureMessageHandler(event.jda, config, translation).sendDecisionMessage(event.user.id, date, reason)
 
             val embed = Embed {

--- a/src/main/kotlin/dev/vxrp/bot/events/modals/NoticeOfDepartureModals.kt
+++ b/src/main/kotlin/dev/vxrp/bot/events/modals/NoticeOfDepartureModals.kt
@@ -23,7 +23,7 @@ class NoticeOfDepartureModals(val event: ModalInteractionEvent, val config: Conf
                 val formatter = DateTimeFormatter.ofPattern("dd.MM.yyyy")
                 LocalDate.parse(date, formatter)
             } catch (_: DateTimeParseException) {
-                event.reply_("Please enter a valid date format to proceed").queue()
+                event.hook.send("Please enter a valid date format to proceed").queue()
                 return
             }
 

--- a/src/main/kotlin/dev/vxrp/bot/events/modals/NoticeOfDepartureModals.kt
+++ b/src/main/kotlin/dev/vxrp/bot/events/modals/NoticeOfDepartureModals.kt
@@ -18,9 +18,9 @@ class NoticeOfDepartureModals(val event: ModalInteractionEvent, val config: Conf
         if (event.modalId.startsWith("notice_of_departure_general")) {
             val date = event.values[0].asString
             val reason = event.values[1].asString
+            val formatter = DateTimeFormatter.ofPattern("dd.MM.yyyy")
 
             try {
-                val formatter = DateTimeFormatter.ofPattern("dd.MM.yyyy")
                 LocalDate.parse(date, formatter)
             } catch (_: DateTimeParseException) {
                 event.hook.send("Please enter a valid date format to proceed").queue()
@@ -28,7 +28,7 @@ class NoticeOfDepartureModals(val event: ModalInteractionEvent, val config: Conf
             }
 
             val currentDate = LocalDate.now()
-            val parsedDate = LocalDate.parse(date, DateTimeFormatter.ofPattern("dd.MM.yyyy"))
+            val parsedDate = LocalDate.parse(date, formatter)
             if (parsedDate.isBefore(currentDate)) {
                 event.hook.send("Please enter a date in the future to proceed").queue()
                 return

--- a/src/main/kotlin/dev/vxrp/bot/events/modals/NoticeOfDepartureModals.kt
+++ b/src/main/kotlin/dev/vxrp/bot/events/modals/NoticeOfDepartureModals.kt
@@ -27,9 +27,7 @@ class NoticeOfDepartureModals(val event: ModalInteractionEvent, val config: Conf
                 return
             }
 
-            // Get current date a day ago to allow for the current day to be selected and to allow different timezones
-            // to be taken into account
-            val currentDate = LocalDate.now().minusDays(1)
+            val currentDate = LocalDate.now()
             val parsedDate = LocalDate.parse(date, DateTimeFormatter.ofPattern("dd.MM.yyyy"))
             if (parsedDate.isBefore(currentDate)) {
                 event.hook.send("Please enter a date in the future to proceed").queue()

--- a/src/main/kotlin/dev/vxrp/bot/events/modals/TicketModals.kt
+++ b/src/main/kotlin/dev/vxrp/bot/events/modals/TicketModals.kt
@@ -17,6 +17,8 @@ import org.slf4j.Logger
 
 class TicketModals(val logger: Logger, val event: ModalInteractionEvent, val config: Config, val translation: Translation) {
     suspend fun init() {
+        if(!event.modalId.startsWith("support_")) return
+        
         event.deferReply(true).queue()
 
         val api = event.jda


### PR DESCRIPTION
1. Actually fix #11, the previous fix didn't use the correct formatter
2. Fixes some `interaction has already been acknowledged` errors
3. Added a check to not allow dates in the past
4. Fixes template of notice of departure not replacing placeholders like &filler&