### PR TITLE
Notice of Departure Command

### DIFF
--- a/src/main/kotlin/dev/vxrp/bot/commands/handler/bot/noticeofdeparture/NoticeOfDepartureCommand.kt
+++ b/src/main/kotlin/dev/vxrp/bot/commands/handler/bot/noticeofdeparture/NoticeOfDepartureCommand.kt
@@ -1,0 +1,15 @@
+package dev.vxrp.bot.commands.handler.bot.noticeofdeparture
+
+import dev.vxrp.configuration.data.Config
+import dev.vxrp.configuration.data.Translation
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
+
+class NoticeOfDepartureCommand(val config: Config,  translation: Translation) {
+    fun view(event: SlashCommandInteractionEvent) {
+
+    }
+
+    fun revoke(event: SlashCommandInteractionEvent) {
+
+    }
+}

--- a/src/main/kotlin/dev/vxrp/bot/commands/handler/bot/noticeofdeparture/NoticeOfDepartureCommand.kt
+++ b/src/main/kotlin/dev/vxrp/bot/commands/handler/bot/noticeofdeparture/NoticeOfDepartureCommand.kt
@@ -1,15 +1,62 @@
 package dev.vxrp.bot.commands.handler.bot.noticeofdeparture
 
+import dev.minn.jda.ktx.messages.Embed
+import dev.minn.jda.ktx.messages.reply_
+import dev.vxrp.bot.modals.NoticeOfDepartureTemplateModals
+import dev.vxrp.bot.noticeofdeparture.enums.ActionId
 import dev.vxrp.configuration.data.Config
 import dev.vxrp.configuration.data.Translation
+import dev.vxrp.database.tables.database.NoticeOfDepartureTable
+import dev.vxrp.util.color.ColorTool
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
 
-class NoticeOfDepartureCommand(val config: Config,  translation: Translation) {
+class NoticeOfDepartureCommand(val config: Config,  val translation: Translation) {
     fun view(event: SlashCommandInteractionEvent) {
+        val user = event.options[0].asUser
+        if (user.isBot) return
+        val handler = NoticeOfDepartureTable().retrieveHandler(user.id)!!
+        val currentDate = LocalDate.now().format(DateTimeFormatter.ofPattern("dd.MM.yyyy"))
+        val endDate = NoticeOfDepartureTable().retrieveEndDate(user.id)
 
+        if (endDate != null) {
+            val embed = Embed {
+                title = ColorTool().useCustomColorCodes(translation.noticeOfDeparture.embedNoticeViewTitle
+                    .replace("%user%", user.name))
+                description = ColorTool().useCustomColorCodes(translation.noticeOfDeparture.embedNoticeViewBody
+                    .replace("%user%", "<@$handler>")
+                    .replace("%current_date%", currentDate)
+                    .replace("%end_date%", endDate))
+            }
+
+            event.reply_("", listOf(embed)).setEphemeral(true).queue()
+        } else {
+            val embed = Embed {
+                color = 0xE74D3C
+                title = ColorTool().useCustomColorCodes(translation.noticeOfDeparture.embedNotFoundTitle)
+                description = ColorTool().useCustomColorCodes(translation.noticeOfDeparture.embedNotFoundBody)
+            }
+
+            event.reply_("", listOf(embed)).setEphemeral(true).queue()
+        }
     }
 
     fun revoke(event: SlashCommandInteractionEvent) {
+        val user = event.options[0].asUser
+        if (user.isBot) return
+        val endDate = NoticeOfDepartureTable().retrieveEndDate(user.id)
 
+        if (endDate != null) {
+            event.replyModal(NoticeOfDepartureTemplateModals(translation).reasonActionModal(ActionId.REVOKING, user.id, endDate)).queue()
+        } else {
+            val embed = Embed {
+                color = 0xE74D3C
+                title = ColorTool().useCustomColorCodes(translation.noticeOfDeparture.embedNotFoundTitle)
+                description = ColorTool().useCustomColorCodes(translation.noticeOfDeparture.embedNotFoundBody)
+            }
+
+            event.reply_("", listOf(embed)).setEphemeral(true).queue()
+        }
     }
 }

--- a/src/main/kotlin/dev/vxrp/bot/commands/listeners/CommandListener.kt
+++ b/src/main/kotlin/dev/vxrp/bot/commands/listeners/CommandListener.kt
@@ -4,6 +4,7 @@ import dev.minn.jda.ktx.events.listener
 import dev.minn.jda.ktx.messages.reply_
 import dev.vxrp.bot.commands.handler.bot.application.ApplicationCommand
 import dev.vxrp.bot.commands.handler.bot.help.HelpCommand
+import dev.vxrp.bot.commands.handler.bot.noticeofdeparture.NoticeOfDepartureCommand
 import dev.vxrp.bot.commands.handler.bot.settings.SettingsCommand
 import dev.vxrp.bot.commands.handler.bot.template.TemplateCommandHandler
 import dev.vxrp.bot.commands.handler.bot.verify.VerifyCommand
@@ -26,7 +27,7 @@ class CommandListener(val api: JDA, val config: Config, val translation: Transla
             for (command in commandList) {
                 if (!event.fullCommandName.contains(command.name)) continue
 
-                if (checkInheritance(command.inherit, event)) break
+                checkInheritance(command.inherit, event)
 
                 for (subCommand in command.subcommands!!) {
                     if (subCommand.name != event.fullCommandName.split(" ".toRegex())[1]) continue
@@ -37,7 +38,7 @@ class CommandListener(val api: JDA, val config: Config, val translation: Transla
         }
     }
 
-    private fun checkInheritance(inherit: String, event: SlashCommandInteractionEvent): Boolean {
+    private fun checkInheritance(inherit: String, event: SlashCommandInteractionEvent) {
         val launchOptionManager = LaunchOptionManager(config, translation)
 
         when (inherit) {
@@ -45,14 +46,14 @@ class CommandListener(val api: JDA, val config: Config, val translation: Transla
                 if (launchOptionManager.checkSectionOption(LaunchOptionType.COMMAND_LISTENER, LaunchOptionSectionType.HELP_COMMAND).engage) {
                     helpCommand(event)
                 }
-                return true
+                return
             }
 
             "commands.template.default" -> {
                 if (launchOptionManager.checkSectionOption(LaunchOptionType.COMMAND_LISTENER, LaunchOptionSectionType.TEMPLATE_COMMAND).engage) {
                     templateCommand(event)
                 }
-                return true
+                return
             }
 
             "commands.verify.default" -> {
@@ -61,7 +62,7 @@ class CommandListener(val api: JDA, val config: Config, val translation: Transla
                         event.reply_("", listOf(embed)).setEphemeral(true).queue()
                     } ?: verifyCommand(event)
                 }
-                return true
+                return
             }
 
             "commands.notice_of_departure.default" -> {
@@ -70,7 +71,7 @@ class CommandListener(val api: JDA, val config: Config, val translation: Transla
                         event.reply_("", listOf(embed)).setEphemeral(true).queue()
                     } ?: noticeOfDepartureCommand(event)
                 }
-                return true
+                return
             }
 
             "commands.regulars.default" -> {
@@ -79,14 +80,14 @@ class CommandListener(val api: JDA, val config: Config, val translation: Transla
                         event.reply_("", listOf(embed)).setEphemeral(true).queue()
                     } ?: regularsCommand(event)
                 }
-                return true
+                return
             }
 
             "commands.settings.default" -> {
                 if (launchOptionManager.checkSectionOption(LaunchOptionType.COMMAND_LISTENER, LaunchOptionSectionType.SETTINGS_COMMAND).engage) {
                     settingsCommand(event)
                 }
-                return true
+                return
             }
 
             "commands.application.default" -> {
@@ -95,17 +96,22 @@ class CommandListener(val api: JDA, val config: Config, val translation: Transla
                         event.reply_("", listOf(embed)).setEphemeral(true).queue()
                     } ?: applicationCommand(event)
                 }
-                return true
+                return
             }
         }
 
-        return false
+        return
     }
 
     private fun checkSubInheritance(inherit: String, event: SlashCommandInteractionEvent): Boolean {
         when (inherit) {
-            "commands.kill.sub" -> {
-                // Test Tes Test
+            "notice_of_departure.view.sub" -> {
+                NoticeOfDepartureCommand(config, translation).view(event)
+                return true
+            }
+
+            "notice_of_departure.revoke.sub" -> {
+                NoticeOfDepartureCommand(config, translation).revoke(event)
                 return true
             }
         }

--- a/src/main/kotlin/dev/vxrp/bot/commands/listeners/CommandListener.kt
+++ b/src/main/kotlin/dev/vxrp/bot/commands/listeners/CommandListener.kt
@@ -106,12 +106,16 @@ class CommandListener(val api: JDA, val config: Config, val translation: Transla
     private fun checkSubInheritance(inherit: String, event: SlashCommandInteractionEvent): Boolean {
         when (inherit) {
             "notice_of_departure.view.sub" -> {
-                NoticeOfDepartureCommand(config, translation).view(event)
+                PermissionManager(config, translation).checkStatus(StatusMessageType.COMMAND, config.settings.noticeOfDeparture.active)?.let { embed ->
+                    event.reply_("", listOf(embed)).setEphemeral(true).queue()
+                } ?: NoticeOfDepartureCommand(config, translation).view(event)
                 return true
             }
 
             "notice_of_departure.revoke.sub" -> {
-                NoticeOfDepartureCommand(config, translation).revoke(event)
+                PermissionManager(config, translation).checkStatus(StatusMessageType.COMMAND, config.settings.noticeOfDeparture.active)?.let { embed ->
+                    event.reply_("", listOf(embed)).setEphemeral(true).queue()
+                } ?: NoticeOfDepartureCommand(config, translation).revoke(event)
                 return true
             }
         }

--- a/src/main/kotlin/dev/vxrp/bot/events/modals/NoticeOfDepartureModals.kt
+++ b/src/main/kotlin/dev/vxrp/bot/events/modals/NoticeOfDepartureModals.kt
@@ -109,7 +109,6 @@ class NoticeOfDepartureModals(val event: ModalInteractionEvent, val config: Conf
             }
 
             event.reply_("", listOf(embed)).setEphemeral(true).queue()
-            event.message?.delete()?.queue()
         }
     }
 }

--- a/src/main/kotlin/dev/vxrp/bot/noticeofdeparture/NoticeOfDepartureManager.kt
+++ b/src/main/kotlin/dev/vxrp/bot/noticeofdeparture/NoticeOfDepartureManager.kt
@@ -1,5 +1,6 @@
 package dev.vxrp.bot.noticeofdeparture
 
+import dev.minn.jda.ktx.coroutines.await
 import dev.vxrp.bot.noticeofdeparture.handler.NoticeOfDepartureCheckerHandler
 import dev.vxrp.bot.noticeofdeparture.handler.NoticeOfDepartureMessageHandler
 import dev.vxrp.configuration.data.Config
@@ -18,6 +19,11 @@ class NoticeOfDepartureManager(val api: JDA, val config: Config, val translation
 
     suspend fun revokeNotice(reason: String, userId: String, date: String) {
         NoticeOfDepartureMessageHandler(api, config, translation).sendRevokedMessage(reason, userId, NoticeOfDepartureTable().retrieveBeginDate(userId)!!, date)
+
+        val channel = api.getTextChannelById(NoticeOfDepartureTable().retrieveChannel(userId)!!)
+        val message = channel?.retrieveMessageById(NoticeOfDepartureTable().retrieveMessage(userId)!!)?.await()
+
+        message?.delete()?.queue()
 
         NoticeOfDepartureTable().deleteEntry(userId)
     }

--- a/src/main/kotlin/dev/vxrp/bot/noticeofdeparture/handler/NoticeOfDepartureMessageHandler.kt
+++ b/src/main/kotlin/dev/vxrp/bot/noticeofdeparture/handler/NoticeOfDepartureMessageHandler.kt
@@ -111,7 +111,7 @@ class NoticeOfDepartureMessageHandler(val api: JDA, val config: Config, val tran
                 translation.noticeOfDeparture.embedNoticeBody
                     .replace("%user%", user.asMention)
                     .replace("%current_date%", currentDate)
-                    .replace("%end_date", endDate)
+                    .replace("%end_date%", endDate)
                     .replace("%reason%", reason)
             )
         }
@@ -134,7 +134,7 @@ class NoticeOfDepartureMessageHandler(val api: JDA, val config: Config, val tran
             description = ColorTool().useCustomColorCodes(
                 translation.noticeOfDeparture.embedRevokedBody
                     .replace("%current_date%", beginDate)
-                    .replace("%end_date", endDate)
+                    .replace("%end_date%", endDate)
                     .replace("%reason%", reason)
             )
         }
@@ -150,7 +150,7 @@ class NoticeOfDepartureMessageHandler(val api: JDA, val config: Config, val tran
             description = ColorTool().useCustomColorCodes(
                 translation.noticeOfDeparture.embedEndedBody
                     .replace("%current_date%", beginDate)
-                    .replace("%end_date", endDate)
+                    .replace("%end_date%", endDate)
             )
         }
 

--- a/src/main/kotlin/dev/vxrp/configuration/data/Translation.kt
+++ b/src/main/kotlin/dev/vxrp/configuration/data/Translation.kt
@@ -666,6 +666,11 @@ data class TranslationNoticeOfDeparture(
     @SerialName("EMBED_NOTICE_BODY")
     val embedNoticeBody: String,
 
+    @SerialName("EMBED_NOTICE_VIEW_TITLE")
+    val embedNoticeViewTitle: String,
+    @SerialName("EMBED_NOTICE_VIEW_BODY")
+    val embedNoticeViewBody: String,
+
     @SerialName("EMBED_ENDED_TITLE")
     val embedEndedTitle: String,
     @SerialName("EMBED_ENDED_BODY")

--- a/src/main/kotlin/dev/vxrp/configuration/data/Translation.kt
+++ b/src/main/kotlin/dev/vxrp/configuration/data/Translation.kt
@@ -634,6 +634,7 @@ data class TranslationNoticeOfDeparture(
     val embedDecisionSentBody: String,
 
     @SerialName("EMBED_ACCEPTED_TITLE")
+
     val embedAcceptedTitle: String,
     @SerialName("EMBED_ACCEPTED_BODY")
     val embedAcceptedBody: String,
@@ -679,6 +680,11 @@ data class TranslationNoticeOfDeparture(
     val embedRevokationSentTitle: String,
     @SerialName("EMBED_REVOKATION_SENT_BODY")
     val embedRevokationSentBody: String,
+
+    @SerialName("EMBED_NOT_FOUND_TITLE")
+    val embedNotFoundTitle: String,
+    @SerialName("EMBED_NOT_FOUND_BODY")
+    val embedNotFoundBody: String,
 )
 
 @Serializable

--- a/src/main/kotlin/dev/vxrp/database/tables/database/NoticeOfDepartureTable.kt
+++ b/src/main/kotlin/dev/vxrp/database/tables/database/NoticeOfDepartureTable.kt
@@ -54,32 +54,18 @@ class NoticeOfDepartureTable {
         return list
     }
 
-    fun retrieveBeginDate(id: String): String? {
-        var date: String? = null
+    fun retrieveHandler(id: String): String? {
+        var handler: String? = null
 
         transaction {
             NoticeOfDepartures.selectAll()
                 .where { NoticeOfDepartures.id eq id }
                 .forEach {
-                    date = it[NoticeOfDepartures.beginDate]
+                    handler = it[NoticeOfDepartures.handlerId]
                 }
         }
 
-        return date
-    }
-
-    fun retrieveEndDate(id: String): String? {
-        var date: String? = null
-
-        transaction {
-            NoticeOfDepartures.selectAll()
-                .where { NoticeOfDepartures.id eq id }
-                .forEach {
-                    date = it[NoticeOfDepartures.endDate]
-                }
-        }
-
-        return date
+        return handler
     }
 
     fun retrieveChannel(id: String): String? {
@@ -108,6 +94,34 @@ class NoticeOfDepartureTable {
         }
 
         return message
+    }
+
+    fun retrieveBeginDate(id: String): String? {
+        var date: String? = null
+
+        transaction {
+            NoticeOfDepartures.selectAll()
+                .where { NoticeOfDepartures.id eq id }
+                .forEach {
+                    date = it[NoticeOfDepartures.beginDate]
+                }
+        }
+
+        return date
+    }
+
+    fun retrieveEndDate(id: String): String? {
+        var date: String? = null
+
+        transaction {
+            NoticeOfDepartures.selectAll()
+                .where { NoticeOfDepartures.id eq id }
+                .forEach {
+                    date = it[NoticeOfDepartures.endDate]
+                }
+        }
+
+        return date
     }
 
     fun retrieveSerial(): Long {

--- a/src/main/kotlin/dev/vxrp/util/color/ColorTool.kt
+++ b/src/main/kotlin/dev/vxrp/util/color/ColorTool.kt
@@ -55,7 +55,7 @@ class ColorTool {
             .replace("&bold&", bold)
             .replace("&reset&", reset)
             .replace("&underline&", underline)
-            .replace("&filler&", singleFiller.repeat(max(0.0, 140.toDouble()).toInt()))
+            .replace("&filler&", singleFiller.repeat(max(0.0, 144.toDouble()).toInt()))
             .replace("&singleFiller&", singleFiller)
     }
 }

--- a/src/main/resources/SCPToolsBot/configs/extra/commands.json
+++ b/src/main/resources/SCPToolsBot/configs/extra/commands.json
@@ -52,7 +52,35 @@
       "inherit": "commands.notice_of_departure.default",
       "name": "notice_of_departure",
       "description": "View information on notices and change data",
-      "defaultPermissions": ["ADMINISTRATOR"]
+      "defaultPermissions": ["ADMINISTRATOR"],
+      "subcommands": [
+        {
+          "inherit": "notice_of_departure.view.sub",
+          "name": "view",
+          "description": "View a notice of departure",
+          "options": [
+            {
+              "type": "USER",
+              "name": "user",
+              "description": "User to query from",
+              "isRequired": true
+            }
+          ]
+        },
+        {
+          "inherit": "notice_of_departure.revoke.sub",
+          "name": "revoke",
+          "description": "Revoke a notice of departure",
+          "options": [
+            {
+              "type": "USER",
+              "name": "user",
+              "description": "User to revoke from",
+              "isRequired": true
+            }
+          ]
+        }
+      ]
     },
     {
       "active": true,

--- a/src/main/resources/SCPToolsBot/lang/de_DE.yml
+++ b/src/main/resources/SCPToolsBot/lang/de_DE.yml
@@ -699,6 +699,9 @@ NOTICE_OF_DEPARTURE:
   EMBED_REVOKATION_SENT_TITLE: "Abmeldung Zurückgezogen"
   EMBED_REVOKATION_SENT_BODY: "Die Abmeldung wird nun zurückgezogen. Der Nutzer wird in kürze darüber benachrichtigt wieso die Abmeldung zurückgezogen wurde"
 
+  EMBED_NOT_FOUND_TITLE: "Abmeldung nicht Gefunden"
+  EMBED_NOT_FOUND_BODY: "Es wurde keine Abmeldung für den von dir angegebenen Nutzer gefunden. Vielleicht wurde sie bereits zurückgezogen/ist abgelaufen."
+
 REGULARS:
 
   EMBED_TEMPLATE_TITLE: "Aktiviere Stammspieler Synchronisierung"

--- a/src/main/resources/SCPToolsBot/lang/de_DE.yml
+++ b/src/main/resources/SCPToolsBot/lang/de_DE.yml
@@ -671,12 +671,24 @@ NOTICE_OF_DEPARTURE:
                         __**Akzeptiert von:**__\n
                         %user%\n
                         
-                        __**Zeit:**__\n
+                        __**Zeitspanne:**__\n
                         ```%current_date% bis %end_date%```
                         
                         __**Akzeptanzgrund:**__\n
                         ```%reason%```
                         "
+
+  EMBED_NOTICE_VIEW_TITLE: "Abmeldung von %user%"
+  EMBED_NOTICE_VIEW_BODY: "
+                          __**Akzeptiert von:**__\n
+                          %user%\n
+                          &filler&
+                          __**Zeitspanne:**__\n
+                          ```%current_date% till %end_date%```
+
+                          **Akzeptanzgrund:**
+                          ```ansi\n&red&Der Akzeptanzgrund kann nicht angezeigt werden, da er nicht lokal gespeichert ist&reset&```
+                          "
 
   EMBED_ENDED_TITLE: "Abmeldung ist Geendet"
   EMBED_ENDED_BODY: "

--- a/src/main/resources/SCPToolsBot/lang/en_US.yml
+++ b/src/main/resources/SCPToolsBot/lang/en_US.yml
@@ -699,6 +699,9 @@ NOTICE_OF_DEPARTURE:
   EMBED_REVOKATION_SENT_TITLE: "Notice of Departure Revoked"
   EMBED_REVOKATION_SENT_BODY: "Notice of Departure is now getting revoked. The user will be notified shortly, providing him with the reason you entered"
 
+  EMBED_NOT_FOUND_TITLE: "Notice of Departure Not Found"
+  EMBED_NOT_FOUND_BODY: "Could not find any notice of departure of the user you entered. Maybe it has already been revoked/ran out."
+
 REGULARS:
 
   EMBED_TEMPLATE_TITLE: "Activate Regular Syncing"

--- a/src/main/resources/SCPToolsBot/lang/en_US.yml
+++ b/src/main/resources/SCPToolsBot/lang/en_US.yml
@@ -677,6 +677,18 @@ NOTICE_OF_DEPARTURE:
                         ```%reason%```
                         "
 
+  EMBED_NOTICE_VIEW_TITLE: "Notice of Departure by %user%"
+  EMBED_NOTICE_VIEW_BODY: "
+                          __**Accepted by:**__\n
+                          %user%\n
+                          &filler&
+                          __**Timespan:**__\n
+                          ```%current_date% till %end_date%```
+
+                          __**Acceptance Reason:**__\n
+                          ```ansi\n&red&The acceptance reason can not be displayed, as it is not saved locally&reset&```
+                          "
+
   EMBED_ENDED_TITLE: "Notice of Departure has Ended"
   EMBED_ENDED_BODY: "
                         Your Notice of Departure has ended and all your benefits going with it have been revoked \n


### PR DESCRIPTION
<!--
  Thank you for creating a PR. Please mark all required information with an 'x' e.g. '- [x]'
  If you have any questions, join the dc.

  NOTICE: If you are creating a PR for fixing an issue, please reference it. If it does not
  exist, please create it and then follow through with the PR.
-->
## Etiquette
- [x] Did you check the contribution guidelines?
- [x] Does this request not already exist in another form?
<!--
  What exactly did you change?
-->
## Changes
- [ ] Bugfix
- [x] Feature
- [ ] Behavior Change
- [ ] Configuration
- [ ] Other: ____
<!--
  How thoroughly did you test your changes?
-->
## Tested
- [ ] Completely
- [x] Mostly
- [ ] Partly
- [ ] Nothing
<!--
  Describe all of your changes and what they purpose is. If you added a new feature, explain
  why you want it implemented and how to use it.
-->
## Description

This request contains one command with two subcommands.

The first command let's the issuer view a notice by querying it from the user.
```sh
/notice_of_departure view user:<user>
```

The second is another way to revoke a notice without using the button on the notice message
```sh
/notice_of_departure view user:<user>
```
