### PR TITLE
Patch/applications

### DIFF
--- a/src/main/kotlin/dev/vxrp/bot/application/ApplicationManager.kt
+++ b/src/main/kotlin/dev/vxrp/bot/application/ApplicationManager.kt
@@ -9,15 +9,13 @@ var applicationTypeSet: HashSet<ApplicationType> = hashSetOf()
 class ApplicationManager(val config: Config, val translation: Translation) {
 
     fun changeApplicationType(roleID: String, name: String? = null, description: String? = null, emoji: String? = null, state: Boolean? = null, initializer: String? = null, member: Int? = null) {
-        for (type in applicationTypeSet) {
-            if (type.roleId != roleID) continue
-
-            var typeName = type.name
-            var typeDescription = type.description
-            var typeEmoji = type.emoji
-            var typeState = type.state
-            var typeInitializer = type.initializer
-            var typeMember = type.member
+        applicationTypeSet.filter { it.roleId == roleID }.forEach {
+            var typeName = it.name
+            var typeDescription = it.description
+            var typeEmoji = it.emoji
+            var typeState = it.state
+            var typeInitializer = it.initializer
+            var typeMember = it.member
 
             if (name != null) typeName = name
             if (description != null) typeDescription = description
@@ -26,18 +24,12 @@ class ApplicationManager(val config: Config, val translation: Translation) {
             if (initializer != null) typeInitializer = initializer
             if (member != null) typeMember = member
 
-            val applicationTypeList = applicationTypeSet
-            applicationTypeList.filter { it.pos == type.pos }.forEach {
-                it.pos = type.pos
-                it.roleId = type.roleId
-                it.name = typeName
-                it.description = typeDescription
-                it.emoji = typeEmoji
-                it.state = typeState
-                it.initializer = typeInitializer
-                it.member = typeMember
-            }
-            break
+            it.name = typeName
+            it.description = typeDescription
+            it.emoji = typeEmoji
+            it.state = typeState
+            it.initializer = typeInitializer
+            it.member = typeMember
         }
     }
 }

--- a/src/main/kotlin/dev/vxrp/bot/application/ApplicationManager.kt
+++ b/src/main/kotlin/dev/vxrp/bot/application/ApplicationManager.kt
@@ -27,8 +27,16 @@ class ApplicationManager(val config: Config, val translation: Translation) {
             if (member != null) typeMember = member
 
             val applicationTypeList = applicationTypeSet
-
-            applicationTypeList.add(ApplicationType(type.pos, type.roleId, typeName, typeDescription, typeEmoji, typeState, typeInitializer, typeMember))
+            applicationTypeList.filter { it.pos == type.pos }.forEach {
+                it.pos = type.pos
+                it.roleId = type.roleId
+                it.name = typeName
+                it.description = typeDescription
+                it.emoji = typeEmoji
+                it.state = typeState
+                it.initializer = typeInitializer
+                it.member = typeMember
+            }
             break
         }
     }

--- a/src/main/kotlin/dev/vxrp/bot/application/ApplicationManager.kt
+++ b/src/main/kotlin/dev/vxrp/bot/application/ApplicationManager.kt
@@ -4,12 +4,12 @@ import dev.vxrp.bot.application.data.ApplicationType
 import dev.vxrp.configuration.data.Config
 import dev.vxrp.configuration.data.Translation
 
-val applicationTypeMap: HashMap<String, MutableList<ApplicationType>> = hashMapOf()
+var applicationTypeSet: HashSet<ApplicationType> = hashSetOf()
 
 class ApplicationManager(val config: Config, val translation: Translation) {
 
-    fun changeApplicationType(userID: String, roleID: String, name: String? = null, description: String? = null, emoji: String? = null, state: Boolean? = null, initializer: String? = null, member: Int? = null) {
-        for (type in applicationTypeMap[userID]!!) {
+    fun changeApplicationType(roleID: String, name: String? = null, description: String? = null, emoji: String? = null, state: Boolean? = null, initializer: String? = null, member: Int? = null) {
+        for (type in applicationTypeSet) {
             if (type.roleId != roleID) continue
 
             var typeName = type.name
@@ -26,10 +26,9 @@ class ApplicationManager(val config: Config, val translation: Translation) {
             if (initializer != null) typeInitializer = initializer
             if (member != null) typeMember = member
 
-            val applicationTypeList = applicationTypeMap[userID]!!
+            val applicationTypeList = applicationTypeSet
 
-            applicationTypeList[type.pos] = ApplicationType(type.pos, type.roleId, typeName, typeDescription, typeEmoji, typeState, typeInitializer, typeMember)
-
+            applicationTypeList.add(ApplicationType(type.pos, type.roleId, typeName, typeDescription, typeEmoji, typeState, typeInitializer, typeMember))
             break
         }
     }

--- a/src/main/kotlin/dev/vxrp/bot/application/ApplicationManager.kt
+++ b/src/main/kotlin/dev/vxrp/bot/application/ApplicationManager.kt
@@ -1,4 +1,4 @@
-package dev.vxrp.bot.application.handler
+package dev.vxrp.bot.application
 
 import dev.vxrp.bot.application.data.ApplicationType
 import dev.vxrp.configuration.data.Config

--- a/src/main/kotlin/dev/vxrp/bot/application/data/ApplicationType.kt
+++ b/src/main/kotlin/dev/vxrp/bot/application/data/ApplicationType.kt
@@ -1,12 +1,12 @@
 package dev.vxrp.bot.application.data
 
 data class ApplicationType (
-    val pos: Int,
-    val roleId: String,
-    val name: String,
-    val description: String,
-    val emoji: String,
-    val state: Boolean,
-    val initializer: String?,
-    val member: Int
+    var pos: Int,
+    var roleId: String,
+    var name: String,
+    var description: String,
+    var emoji: String,
+    var state: Boolean,
+    var initializer: String?,
+    var member: Int
 )

--- a/src/main/kotlin/dev/vxrp/bot/application/handler/ApplicationMessageHandler.kt
+++ b/src/main/kotlin/dev/vxrp/bot/application/handler/ApplicationMessageHandler.kt
@@ -49,9 +49,7 @@ class ApplicationMessageHandler(val config: Config, val translation: Translation
     fun editActivationMessage(userId: String, roleId: String, channel: TextChannel, messageId: String, name: String? = null, description: String? = null, emoji: String? = null, state: Boolean? = null, initializer: String? = null, member: Int? = null) {
         ApplicationManager(config, translation).changeApplicationType(roleId, name, description, emoji, state, initializer, member)
 
-        channel.editMessage(messageId, "", listOf(createMessage(false))).setActionRow(
-            applicationActionRow(userId, applicationTypeSet.toList())
-        ).queue()
+        channel.editMessage(messageId, "", listOf(createMessage(false))).setActionRow(applicationActionRow(userId, applicationTypeSet.toList())).queue()
     }
 
     suspend fun sendApplicationMessage(api: JDA, channel: TextChannel, state: Boolean) {
@@ -66,10 +64,9 @@ class ApplicationMessageHandler(val config: Config, val translation: Translation
         val embed = Embed {
             color = embedColor
             title = ColorTool().useCustomColorCodes(translation.application.embedApplicationMessageTitle)
-            description = ColorTool().useCustomColorCodes(
-                translation.application.embedApplicationMessageBody
-                    .replace("%status%", status)
-                    .replace("%active_roles%", roleStringPair.first.toString())
+            description = ColorTool().useCustomColorCodes(translation.application.embedApplicationMessageBody
+                .replace("%status%", status)
+                .replace("%active_roles%", roleStringPair.first.toString())
             )
         }
 
@@ -93,9 +90,7 @@ class ApplicationMessageHandler(val config: Config, val translation: Translation
             ).await()
         }
 
-        for (type in applicationTypeSet) {
-            ApplicationTypeTable().changeType(type.roleId, type.state, type.member,type.initializer)
-        }
+        for (type in applicationTypeSet) ApplicationTypeTable().changeType(type.roleId, type.state, type.member,type.initializer)
         if (message == null) {
             logger.error("Could not mirror applied application settings to database")
             return
@@ -112,10 +107,9 @@ class ApplicationMessageHandler(val config: Config, val translation: Translation
         return Embed {
             color = 0x2ECC70
             title = ColorTool().useCustomColorCodes(translation.application.embedActivationMenuTitle)
-            description = ColorTool().useCustomColorCodes(
-                translation.application.embedActivationMenuBody
-                    .replace("%status%", translation.application.textStatusDeactivated)
-                    .replace("%active_roles%", roleStringPair.first.toString())
+            description = ColorTool().useCustomColorCodes(translation.application.embedActivationMenuBody
+                .replace("%status%", translation.application.textStatusDeactivated)
+                .replace("%active_roles%", roleStringPair.first.toString())
             )
         }
     }
@@ -136,24 +130,12 @@ class ApplicationMessageHandler(val config: Config, val translation: Translation
         for (type in config.ticket.applicationTypes) {
             count += 1
 
-            applicationTypeList.add(
-                ApplicationType(
-                    count,
-                    type.roleID,
-                    type.name,
-                    type.description,
-                    type.emoji,
-                    false,
-                    null,
-                    0
-                )
-            )
+            applicationTypeList.add(ApplicationType(count, type.roleID, type.name, type.description, type.emoji, false, null, 0))
 
-            stringBuilder.append(
-                ColorTool().useCustomColorCodes(translation.application.textRoleStatusTemplate
-                    .replace("%roleId%", type.roleID)
-                    .replace("%status%", deactivated)
-                    .replace("%max_candidates%", "0")))
+            stringBuilder.append(ColorTool().useCustomColorCodes(translation.application.textRoleStatusTemplate
+                .replace("%roleId%", type.roleID)
+                .replace("%status%", deactivated)
+                .replace("%max_candidates%", "0")))
         }
 
         return Pair(stringBuilder, applicationTypeList)
@@ -169,11 +151,10 @@ class ApplicationMessageHandler(val config: Config, val translation: Translation
             if (type.state) status = activated
             if (!type.state) status = deactivated
 
-            stringBuilder.append(
-                ColorTool().useCustomColorCodes(translation.application.textRoleStatusTemplate
-                    .replace("%roleId%", type.roleId)
-                    .replace("%status%", status!!)
-                    .replace("%max_candidates%", type.member.toString())))
+            stringBuilder.append(ColorTool().useCustomColorCodes(translation.application.textRoleStatusTemplate
+                .replace("%roleId%", type.roleId)
+                .replace("%status%", status!!)
+                .replace("%max_candidates%", type.member.toString())))
         }
 
         return Pair(stringBuilder, applicationTypeList)
@@ -182,12 +163,9 @@ class ApplicationMessageHandler(val config: Config, val translation: Translation
     private fun applicationActionRow(userId: String, types: List<ApplicationType>?): Collection<ItemComponent> {
         val rows: MutableCollection<ItemComponent> = ArrayList()
 
-        val add = Button.success("application_activation_add:$userId", translation.buttons.textApplicationActivationAdd).withEmoji(
-            Emoji.fromFormatted("➕"))
-        var remove = Button.danger("application_activation_remove:$userId", translation.buttons.textApplicationActivationRemove).withEmoji(
-            Emoji.fromFormatted("➖"))
-        var completeSetup = Button.primary("application_activation_complete_setup:$userId", translation.buttons.textApplicationActivationCompleteSetup).withEmoji(
-            Emoji.fromFormatted("💽"))
+        val add = Button.success("application_activation_add:$userId", translation.buttons.textApplicationActivationAdd).withEmoji(Emoji.fromFormatted("➕"))
+        var remove = Button.danger("application_activation_remove:$userId", translation.buttons.textApplicationActivationRemove).withEmoji(Emoji.fromFormatted("➖"))
+        var completeSetup = Button.primary("application_activation_complete_setup:$userId", translation.buttons.textApplicationActivationCompleteSetup).withEmoji(Emoji.fromFormatted("💽"))
 
         if (types == null) {
             remove = remove.asDisabled()

--- a/src/main/kotlin/dev/vxrp/bot/application/handler/ApplicationMessageHandler.kt
+++ b/src/main/kotlin/dev/vxrp/bot/application/handler/ApplicationMessageHandler.kt
@@ -1,13 +1,13 @@
-package dev.vxrp.bot.application
+package dev.vxrp.bot.application.handler
 
 import dev.minn.jda.ktx.coroutines.await
 import dev.minn.jda.ktx.messages.Embed
 import dev.minn.jda.ktx.messages.editMessage
 import dev.minn.jda.ktx.messages.send
+import dev.vxrp.bot.application.ApplicationManager
+import dev.vxrp.bot.application.applicationTypeMap
 import dev.vxrp.bot.application.data.ApplicationType
 import dev.vxrp.bot.application.enums.MessageType
-import dev.vxrp.bot.application.handler.ApplicationManager
-import dev.vxrp.bot.application.handler.applicationTypeMap
 import dev.vxrp.configuration.data.Config
 import dev.vxrp.configuration.data.Translation
 import dev.vxrp.database.tables.database.ApplicationTypeTable
@@ -41,7 +41,9 @@ class ApplicationMessageHandler(val config: Config, val translation: Translation
         }
 
         val actionRow: MutableCollection<ItemComponent> = ArrayList()
-        actionRow.add(Button.danger("application_deactivate", translation.buttons.textApplicationDeactivate).withEmoji(Emoji.fromFormatted("🪫")))
+        actionRow.add(
+            Button.danger("application_deactivate", translation.buttons.textApplicationDeactivate).withEmoji(
+                Emoji.fromFormatted("🪫")))
 
         return Pair(embed, actionRow)
     }
@@ -66,9 +68,11 @@ class ApplicationMessageHandler(val config: Config, val translation: Translation
         val embed = Embed {
             color = embedColor
             title = ColorTool().useCustomColorCodes(translation.application.embedApplicationMessageTitle)
-            description = ColorTool().useCustomColorCodes(translation.application.embedApplicationMessageBody
-                .replace("%status%", status)
-                .replace("%active_roles%", roleStringPair.first.toString()))
+            description = ColorTool().useCustomColorCodes(
+                translation.application.embedApplicationMessageBody
+                    .replace("%status%", status)
+                    .replace("%active_roles%", roleStringPair.first.toString())
+            )
         }
 
         val applicationMessage = MessageTable().queryFromTable(MessageType.APPLICATION)
@@ -110,9 +114,11 @@ class ApplicationMessageHandler(val config: Config, val translation: Translation
         return Embed {
             color = 0x2ECC70
             title = ColorTool().useCustomColorCodes(translation.application.embedActivationMenuTitle)
-            description = ColorTool().useCustomColorCodes(translation.application.embedActivationMenuBody
-                .replace("%status%", translation.application.textStatusDeactivated)
-                .replace("%active_roles%", roleStringPair.first.toString()))
+            description = ColorTool().useCustomColorCodes(
+                translation.application.embedActivationMenuBody
+                    .replace("%status%", translation.application.textStatusDeactivated)
+                    .replace("%active_roles%", roleStringPair.first.toString())
+            )
         }
     }
 
@@ -132,7 +138,18 @@ class ApplicationMessageHandler(val config: Config, val translation: Translation
         for (type in config.ticket.applicationTypes) {
             count += 1
 
-            applicationTypeList.add(ApplicationType(count, type.roleID, type.name,type.description, type.emoji, false, null, 0))
+            applicationTypeList.add(
+                ApplicationType(
+                    count,
+                    type.roleID,
+                    type.name,
+                    type.description,
+                    type.emoji,
+                    false,
+                    null,
+                    0
+                )
+            )
 
             stringBuilder.append(
                 ColorTool().useCustomColorCodes(translation.application.textRoleStatusTemplate
@@ -167,9 +184,12 @@ class ApplicationMessageHandler(val config: Config, val translation: Translation
     private fun applicationActionRow(userId: String, types: List<ApplicationType>?): Collection<ItemComponent> {
         val rows: MutableCollection<ItemComponent> = ArrayList()
 
-        val add = Button.success("application_activation_add:$userId", translation.buttons.textApplicationActivationAdd).withEmoji(Emoji.fromFormatted("➕"))
-        var remove = Button.danger("application_activation_remove:$userId", translation.buttons.textApplicationActivationRemove).withEmoji(Emoji.fromFormatted("➖"))
-        var completeSetup = Button.primary("application_activation_complete_setup:$userId", translation.buttons.textApplicationActivationCompleteSetup).withEmoji(Emoji.fromFormatted("💽"))
+        val add = Button.success("application_activation_add:$userId", translation.buttons.textApplicationActivationAdd).withEmoji(
+            Emoji.fromFormatted("➕"))
+        var remove = Button.danger("application_activation_remove:$userId", translation.buttons.textApplicationActivationRemove).withEmoji(
+            Emoji.fromFormatted("➖"))
+        var completeSetup = Button.primary("application_activation_complete_setup:$userId", translation.buttons.textApplicationActivationCompleteSetup).withEmoji(
+            Emoji.fromFormatted("💽"))
 
         if (types == null) {
             remove = remove.asDisabled()

--- a/src/main/kotlin/dev/vxrp/bot/commands/handler/bot/application/ApplicationCommand.kt
+++ b/src/main/kotlin/dev/vxrp/bot/commands/handler/bot/application/ApplicationCommand.kt
@@ -1,7 +1,7 @@
 package dev.vxrp.bot.commands.handler.bot.application
 
 import dev.minn.jda.ktx.messages.reply_
-import dev.vxrp.bot.application.ApplicationMessageHandler
+import dev.vxrp.bot.application.handler.ApplicationMessageHandler
 import dev.vxrp.configuration.data.Config
 import dev.vxrp.configuration.data.Translation
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent

--- a/src/main/kotlin/dev/vxrp/bot/events/buttons/ApplicationButtons.kt
+++ b/src/main/kotlin/dev/vxrp/bot/events/buttons/ApplicationButtons.kt
@@ -5,7 +5,7 @@ import dev.minn.jda.ktx.messages.reply_
 import dev.vxrp.bot.application.handler.ApplicationMessageHandler
 import dev.vxrp.bot.application.data.ApplicationType
 import dev.vxrp.bot.application.ApplicationManager
-import dev.vxrp.bot.application.applicationTypeMap
+import dev.vxrp.bot.application.applicationTypeSet
 import dev.vxrp.configuration.data.Config
 import dev.vxrp.configuration.data.Translation
 import dev.vxrp.util.color.ColorTool
@@ -27,7 +27,7 @@ class ApplicationButtons(val event: ButtonInteractionEvent, val config: Config, 
 
             event.reply_("", listOf(embed)).addActionRow(
                 StringSelectMenu.create("application_activation_add:${event.user.id}:${event.message.id}").also {
-                    for (application in applicationTypeMap[event.user.id]!!) {
+                    for (application in applicationTypeSet) {
                         it.addOption(application.name, application.roleId, application.description, Emoji.fromFormatted(application.emoji))
                     }
                 }.build()
@@ -43,7 +43,7 @@ class ApplicationButtons(val event: ButtonInteractionEvent, val config: Config, 
 
             event.reply_("", listOf(embed)).addActionRow(
                 StringSelectMenu.create("application_activation_remove:${event.user.id}:${event.messageId}").also {
-                    for (application in applicationTypeMap[event.user.id]!!) {
+                    for (application in applicationTypeSet) {
                         it.addOption(application.name, application.roleId, application.description, Emoji.fromFormatted(application.emoji))
                     }
                 }.build()
@@ -53,7 +53,7 @@ class ApplicationButtons(val event: ButtonInteractionEvent, val config: Config, 
         if (event.button.id?.startsWith("application_activation_complete_setup") == true && !nullCheck()) {
             if (config.ticket.settings.applicationMessageChannel != "") {
                 event.message.delete().queue()
-                ApplicationMessageHandler(config, translation).sendApplicationMessage(event.jda, event.user.id, event.jda.getTextChannelById(config.ticket.settings.applicationMessageChannel)!!, true)
+                ApplicationMessageHandler(config, translation).sendApplicationMessage(event.jda, event.jda.getTextChannelById(config.ticket.settings.applicationMessageChannel)!!, true)
                 val embed = Embed {
                     color = 0x2ECC70
                     title = ColorTool().useCustomColorCodes(translation.application.embedApplicationActivatedTitle)
@@ -76,13 +76,13 @@ class ApplicationButtons(val event: ButtonInteractionEvent, val config: Config, 
                     listOfTypes.add(ApplicationType(position, type.roleID, "/", "/", "/", false, event.user.id, 0))
                 }
 
-                applicationTypeMap[event.user.id] = listOfTypes
+                applicationTypeSet = listOfTypes.toHashSet()
 
                 for (type in config.ticket.applicationTypes) {
                     ApplicationManager(config, translation).changeApplicationType(event.user.id, type.roleID, initializer = event.user.id, state = false, member = 0)
                 }
 
-                ApplicationMessageHandler(config, translation).sendApplicationMessage(event.jda, event.user.id, event.jda.getTextChannelById(config.ticket.settings.applicationMessageChannel)!!, false)
+                ApplicationMessageHandler(config, translation).sendApplicationMessage(event.jda, event.jda.getTextChannelById(config.ticket.settings.applicationMessageChannel)!!, false)
                 val embed = Embed {
                     color = 0xE74D3C
                     title = ColorTool().useCustomColorCodes(translation.application.embedApplicationDeactivatedTitle)
@@ -111,7 +111,7 @@ class ApplicationButtons(val event: ButtonInteractionEvent, val config: Config, 
     }
 
     private fun nullCheck(): Boolean {
-        if (applicationTypeMap.isNotEmpty()) return false
+        if (applicationTypeSet.isNotEmpty()) return false
         event.message.delete().queue()
         event.reply_("This message has expired, please execute the command again").setEphemeral(true).queue()
 

--- a/src/main/kotlin/dev/vxrp/bot/events/buttons/ApplicationButtons.kt
+++ b/src/main/kotlin/dev/vxrp/bot/events/buttons/ApplicationButtons.kt
@@ -2,10 +2,10 @@ package dev.vxrp.bot.events.buttons
 
 import dev.minn.jda.ktx.messages.Embed
 import dev.minn.jda.ktx.messages.reply_
-import dev.vxrp.bot.application.handler.ApplicationMessageHandler
-import dev.vxrp.bot.application.data.ApplicationType
 import dev.vxrp.bot.application.ApplicationManager
 import dev.vxrp.bot.application.applicationTypeSet
+import dev.vxrp.bot.application.data.ApplicationType
+import dev.vxrp.bot.application.handler.ApplicationMessageHandler
 import dev.vxrp.configuration.data.Config
 import dev.vxrp.configuration.data.Translation
 import dev.vxrp.util.color.ColorTool

--- a/src/main/kotlin/dev/vxrp/bot/events/buttons/ApplicationButtons.kt
+++ b/src/main/kotlin/dev/vxrp/bot/events/buttons/ApplicationButtons.kt
@@ -2,10 +2,10 @@ package dev.vxrp.bot.events.buttons
 
 import dev.minn.jda.ktx.messages.Embed
 import dev.minn.jda.ktx.messages.reply_
-import dev.vxrp.bot.application.ApplicationMessageHandler
+import dev.vxrp.bot.application.handler.ApplicationMessageHandler
 import dev.vxrp.bot.application.data.ApplicationType
-import dev.vxrp.bot.application.handler.ApplicationManager
-import dev.vxrp.bot.application.handler.applicationTypeMap
+import dev.vxrp.bot.application.ApplicationManager
+import dev.vxrp.bot.application.applicationTypeMap
 import dev.vxrp.configuration.data.Config
 import dev.vxrp.configuration.data.Translation
 import dev.vxrp.util.color.ColorTool

--- a/src/main/kotlin/dev/vxrp/bot/events/modals/ApplicationModals.kt
+++ b/src/main/kotlin/dev/vxrp/bot/events/modals/ApplicationModals.kt
@@ -1,6 +1,6 @@
 package dev.vxrp.bot.events.modals
 
-import dev.vxrp.bot.application.ApplicationMessageHandler
+import dev.vxrp.bot.application.handler.ApplicationMessageHandler
 import dev.vxrp.configuration.data.Config
 import dev.vxrp.configuration.data.Translation
 import net.dv8tion.jda.api.events.interaction.ModalInteractionEvent

--- a/src/main/kotlin/dev/vxrp/bot/events/stringSelectMenus/ApplicationStringSelectMenus.kt
+++ b/src/main/kotlin/dev/vxrp/bot/events/stringSelectMenus/ApplicationStringSelectMenus.kt
@@ -2,7 +2,7 @@ package dev.vxrp.bot.events.stringSelectMenus
 
 import dev.minn.jda.ktx.messages.Embed
 import dev.minn.jda.ktx.messages.reply_
-import dev.vxrp.bot.application.ApplicationMessageHandler
+import dev.vxrp.bot.application.handler.ApplicationMessageHandler
 import dev.vxrp.bot.modals.ApplicationTemplateModals
 import dev.vxrp.bot.modals.TicketTemplateModals
 import dev.vxrp.configuration.data.Config

--- a/src/main/kotlin/dev/vxrp/database/tables/database/ApplicationTypeTable.kt
+++ b/src/main/kotlin/dev/vxrp/database/tables/database/ApplicationTypeTable.kt
@@ -54,6 +54,24 @@ class ApplicationTypeTable {
         }
     }
 
+    fun getAllEntrys(): List<ApplicationType>? {
+        val typeList = mutableListOf<ApplicationType>()
+
+        transaction {
+            ApplicationTypes.selectAll()
+                .forEach {
+                    typeList.add(ApplicationType(
+                        it[ApplicationTypes.roleId],
+                        it[ApplicationTypes.active],
+                        it[ApplicationTypes.members],
+                        it[ApplicationTypes.initializer]
+                    ))
+                }
+        }
+
+        return typeList
+    }
+
     fun query(roleId: String): ApplicationType? {
         var applicationType: ApplicationType? = null
 


### PR DESCRIPTION
<!--
  Thank you for creating a PR. Please mark all required information with an 'x' e.g. '- [x]'
  If you have any questions, join the dc.

  NOTICE: If you are creating a PR for fixing an issue, please reference it. If it does not
  exist, please create it and then follow through with the PR.
-->
## Etiquette
- [x] Did you check the contribution guidelines?
- [x] Does this request not already exist in another form?
<!--
  What exactly did you change?
-->
## Changes
- [ ] Bugfix
- [ ] Feature
- [x] Behavior Change
- [ ] Configuration
- [ ] Other: ____
<!--
  How thoroughly did you test your changes?
-->
## Tested
- [ ] Completely
- [x] Mostly
- [ ] Partly
- [ ] Nothing
<!--
  Describe all of your changes and what they purpose is. If you added a new feature, explain
  why you want it implemented and how to use it.
-->
## Description

Applications are now globally saved using a hashset instead of a map. This allows multible users to edit the same configuration simultaneously. The currently saved application types will now be displayed on initial `/application active` usage.
