### PR TITLE
Fix #44 and adding way to configure custom formatter

### DIFF
--- a/src/main/kotlin/dev/vxrp/bot/commands/handler/bot/noticeofdeparture/NoticeOfDepartureCommand.kt
+++ b/src/main/kotlin/dev/vxrp/bot/commands/handler/bot/noticeofdeparture/NoticeOfDepartureCommand.kt
@@ -17,7 +17,7 @@ class NoticeOfDepartureCommand(val config: Config,  val translation: Translation
         val user = event.options[0].asUser
         if (user.isBot) return
         val handler = NoticeOfDepartureTable().retrieveHandler(user.id)!!
-        val currentDate = LocalDate.now().format(DateTimeFormatter.ofPattern("dd.MM.yyyy"))
+        val currentDate = LocalDate.now().format(DateTimeFormatter.ofPattern(config.settings.noticeOfDeparture.dateFormatting))
         val endDate = NoticeOfDepartureTable().retrieveEndDate(user.id)
 
         if (endDate != null) {

--- a/src/main/kotlin/dev/vxrp/bot/commands/handler/bot/noticeofdeparture/NoticeOfDepartureCommand.kt
+++ b/src/main/kotlin/dev/vxrp/bot/commands/handler/bot/noticeofdeparture/NoticeOfDepartureCommand.kt
@@ -48,7 +48,7 @@ class NoticeOfDepartureCommand(val config: Config,  val translation: Translation
         val endDate = NoticeOfDepartureTable().retrieveEndDate(user.id)
 
         if (endDate != null) {
-            event.replyModal(NoticeOfDepartureTemplateModals(translation).reasonActionModal(ActionId.REVOKING, user.id, endDate)).queue()
+            event.replyModal(NoticeOfDepartureTemplateModals(config, translation).reasonActionModal(ActionId.REVOKING, user.id, endDate)).queue()
         } else {
             val embed = Embed {
                 color = 0xE74D3C

--- a/src/main/kotlin/dev/vxrp/bot/events/buttons/NoticeOfDepartureButtons.kt
+++ b/src/main/kotlin/dev/vxrp/bot/events/buttons/NoticeOfDepartureButtons.kt
@@ -12,7 +12,7 @@ import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent
 class NoticeOfDepartureButtons(val event: ButtonInteractionEvent, val config: Config, val translation: Translation) {
     suspend fun init() {
         if (event.button.id?.startsWith("notice_of_departure_file") == true) {
-            event.replyModal(NoticeOfDepartureTemplateModals(translation).generalModal()).queue()
+            event.replyModal(NoticeOfDepartureTemplateModals(config, translation).generalModal()).queue()
         }
 
         if (event.button.id?.startsWith("notice_of_departure_decision_accept") == true) {
@@ -22,7 +22,7 @@ class NoticeOfDepartureButtons(val event: ButtonInteractionEvent, val config: Co
             val userId = splittetId[1]
             val endTime = splittetId[2]
 
-            event.replyModal(NoticeOfDepartureTemplateModals(translation).reasonActionModal(ActionId.ACCEPTING, userId, endTime)).queue()
+            event.replyModal(NoticeOfDepartureTemplateModals(config, translation).reasonActionModal(ActionId.ACCEPTING, userId, endTime)).queue()
         }
 
         if (event.button.id?.startsWith("notice_of_departure_decision_dismiss") == true) {
@@ -32,7 +32,7 @@ class NoticeOfDepartureButtons(val event: ButtonInteractionEvent, val config: Co
             val userId = splittetId[1]
             val endTime = splittetId[2]
 
-            event.replyModal(NoticeOfDepartureTemplateModals(translation).reasonActionModal(ActionId.DISMISSING, userId, endTime)).queue()
+            event.replyModal(NoticeOfDepartureTemplateModals(config, translation).reasonActionModal(ActionId.DISMISSING, userId, endTime)).queue()
         }
 
         if (event.button.id?.startsWith("notice_of_departure_revoke") == true) {
@@ -42,7 +42,7 @@ class NoticeOfDepartureButtons(val event: ButtonInteractionEvent, val config: Co
             val userId = splittetId[1]
             val endTime = splittetId[2]
 
-            event.replyModal(NoticeOfDepartureTemplateModals(translation).reasonActionModal(ActionId.REVOKING, userId, endTime)).queue()
+            event.replyModal(NoticeOfDepartureTemplateModals(config, translation).reasonActionModal(ActionId.REVOKING, userId, endTime)).queue()
         }
     }
 

--- a/src/main/kotlin/dev/vxrp/bot/events/buttons/NoticeOfDepartureButtons.kt
+++ b/src/main/kotlin/dev/vxrp/bot/events/buttons/NoticeOfDepartureButtons.kt
@@ -17,7 +17,6 @@ class NoticeOfDepartureButtons(val event: ButtonInteractionEvent, val config: Co
 
         if (event.button.id?.startsWith("notice_of_departure_decision_accept") == true) {
             if(permissionCheck(PermissionType.NOTICE_OF_DEPARTURES)) return
-            event.deferReply(true).queue()
             val splittetId = event.button.id!!.split(":")
 
             val userId = splittetId[1]
@@ -28,7 +27,6 @@ class NoticeOfDepartureButtons(val event: ButtonInteractionEvent, val config: Co
 
         if (event.button.id?.startsWith("notice_of_departure_decision_dismiss") == true) {
             if(permissionCheck(PermissionType.NOTICE_OF_DEPARTURES)) return
-            event.deferReply(true).queue()
             val splittetId = event.button.id!!.split(":")
 
             val userId = splittetId[1]
@@ -38,7 +36,6 @@ class NoticeOfDepartureButtons(val event: ButtonInteractionEvent, val config: Co
         }
 
         if (event.button.id?.startsWith("notice_of_departure_revoke") == true) {
-            event.deferReply(true).queue()
             if(permissionCheck(PermissionType.NOTICE_OF_DEPARTURES)) return
             val splittetId = event.button.id!!.split(":")
 

--- a/src/main/kotlin/dev/vxrp/bot/events/buttons/NoticeOfDepartureButtons.kt
+++ b/src/main/kotlin/dev/vxrp/bot/events/buttons/NoticeOfDepartureButtons.kt
@@ -17,6 +17,7 @@ class NoticeOfDepartureButtons(val event: ButtonInteractionEvent, val config: Co
 
         if (event.button.id?.startsWith("notice_of_departure_decision_accept") == true) {
             if(permissionCheck(PermissionType.NOTICE_OF_DEPARTURES)) return
+            event.deferReply(true).queue()
             val splittetId = event.button.id!!.split(":")
 
             val userId = splittetId[1]
@@ -27,6 +28,7 @@ class NoticeOfDepartureButtons(val event: ButtonInteractionEvent, val config: Co
 
         if (event.button.id?.startsWith("notice_of_departure_decision_dismiss") == true) {
             if(permissionCheck(PermissionType.NOTICE_OF_DEPARTURES)) return
+            event.deferReply(true).queue()
             val splittetId = event.button.id!!.split(":")
 
             val userId = splittetId[1]
@@ -36,6 +38,7 @@ class NoticeOfDepartureButtons(val event: ButtonInteractionEvent, val config: Co
         }
 
         if (event.button.id?.startsWith("notice_of_departure_revoke") == true) {
+            event.deferReply(true).queue()
             if(permissionCheck(PermissionType.NOTICE_OF_DEPARTURES)) return
             val splittetId = event.button.id!!.split(":")
 

--- a/src/main/kotlin/dev/vxrp/bot/events/modals/NoticeOfDepartureModals.kt
+++ b/src/main/kotlin/dev/vxrp/bot/events/modals/NoticeOfDepartureModals.kt
@@ -19,7 +19,7 @@ class NoticeOfDepartureModals(val event: ModalInteractionEvent, val config: Conf
         if (event.modalId.startsWith("notice_of_departure_general")) {
             val date = event.values[0].asString
             val reason = event.values[1].asString
-            val formatter = DateTimeFormatter.ofPattern("dd.MM.yyyy")
+            val formatter = DateTimeFormatter.ofPattern(config.settings.noticeOfDeparture.dateFormatting)
 
             val parsedDate = try {
                 LocalDate.parse(date, formatter)

--- a/src/main/kotlin/dev/vxrp/bot/events/modals/NoticeOfDepartureModals.kt
+++ b/src/main/kotlin/dev/vxrp/bot/events/modals/NoticeOfDepartureModals.kt
@@ -27,7 +27,8 @@ class NoticeOfDepartureModals(val event: ModalInteractionEvent, val config: Conf
                 val embed = Embed {
                     color = 0xE74D3C
                     title = ColorTool().useCustomColorCodes(translation.noticeOfDeparture.embedEnterValidDateTitle)
-                    description = ColorTool().useCustomColorCodes(translation.noticeOfDeparture.embedEnterValidDateBody)
+                    description = ColorTool().useCustomColorCodes(translation.noticeOfDeparture.embedEnterValidDateBody
+                        .replace("%formatter%", config.settings.noticeOfDeparture.dateFormatting))
                 }
 
                 event.hook.send("", listOf(embed)).setEphemeral(true).queue()

--- a/src/main/kotlin/dev/vxrp/bot/events/modals/NoticeOfDepartureModals.kt
+++ b/src/main/kotlin/dev/vxrp/bot/events/modals/NoticeOfDepartureModals.kt
@@ -1,7 +1,7 @@
 package dev.vxrp.bot.events.modals
 
 import dev.minn.jda.ktx.messages.Embed
-import dev.minn.jda.ktx.messages.reply_
+import dev.minn.jda.ktx.messages.send
 import dev.vxrp.bot.noticeofdeparture.NoticeOfDepartureManager
 import dev.vxrp.bot.noticeofdeparture.handler.NoticeOfDepartureMessageHandler
 import dev.vxrp.configuration.data.Config
@@ -14,6 +14,7 @@ import java.time.format.DateTimeParseException
 
 class NoticeOfDepartureModals(val event: ModalInteractionEvent, val config: Config, val translation: Translation) {
     suspend fun init() {
+        event.deferReply(true).queue()
         if (event.modalId.startsWith("notice_of_departure_general")) {
             val date = event.values[0].asString
             val reason = event.values[1].asString
@@ -28,7 +29,7 @@ class NoticeOfDepartureModals(val event: ModalInteractionEvent, val config: Conf
                     description = ColorTool().useCustomColorCodes(translation.noticeOfDeparture.embedEnterValidDateBody)
                 }
 
-                event.reply_("", listOf(embed)).setEphemeral(true).queue()
+                event.hook.send("", listOf(embed)).setEphemeral(true).queue()
                 return
             }
 
@@ -40,7 +41,7 @@ class NoticeOfDepartureModals(val event: ModalInteractionEvent, val config: Conf
                     description = ColorTool().useCustomColorCodes(translation.noticeOfDeparture.embedEnterFutureDateBody)
                 }
 
-                event.reply_("", listOf(embed)).setEphemeral(true).queue()
+                event.hook.send("", listOf(embed)).setEphemeral(true).queue()
                 return
             }
 
@@ -52,7 +53,7 @@ class NoticeOfDepartureModals(val event: ModalInteractionEvent, val config: Conf
                 description = ColorTool().useCustomColorCodes(translation.noticeOfDeparture.embedDecisionSentBody)
             }
 
-            event.reply_("", listOf(embed)).setEphemeral(true).queue()
+            event.hook.send("", listOf(embed)).setEphemeral(true).queue()
         }
 
         if (event.modalId.startsWith("notice_of_departure_reason_action_ACCEPTING")) {
@@ -71,7 +72,7 @@ class NoticeOfDepartureModals(val event: ModalInteractionEvent, val config: Conf
                 description = ColorTool().useCustomColorCodes(translation.noticeOfDeparture.embedAcceptationSentBody)
             }
 
-            event.reply_("", listOf(embed)).setEphemeral(true).queue()
+            event.hook.send("", listOf(embed)).setEphemeral(true).queue()
             event.message?.delete()?.queue()
         }
 
@@ -89,7 +90,7 @@ class NoticeOfDepartureModals(val event: ModalInteractionEvent, val config: Conf
                 description = ColorTool().useCustomColorCodes(translation.noticeOfDeparture.embedDismissingSentBody)
             }
 
-            event.reply_("", listOf(embed)).setEphemeral(true).queue()
+            event.hook.send("", listOf(embed)).setEphemeral(true).queue()
             event.message?.delete()?.queue()
         }
 
@@ -108,7 +109,7 @@ class NoticeOfDepartureModals(val event: ModalInteractionEvent, val config: Conf
                 description = ColorTool().useCustomColorCodes(translation.noticeOfDeparture.embedRevokationSentBody)
             }
 
-            event.reply_("", listOf(embed)).setEphemeral(true).queue()
+            event.hook.send("", listOf(embed)).setEphemeral(true).queue()
         }
     }
 }

--- a/src/main/kotlin/dev/vxrp/bot/events/modals/NoticeOfDepartureModals.kt
+++ b/src/main/kotlin/dev/vxrp/bot/events/modals/NoticeOfDepartureModals.kt
@@ -15,6 +15,7 @@ import java.time.format.DateTimeParseException
 class NoticeOfDepartureModals(val event: ModalInteractionEvent, val config: Config, val translation: Translation) {
     suspend fun init() {
         event.deferReply(true).queue()
+
         if (event.modalId.startsWith("notice_of_departure_general")) {
             val date = event.values[0].asString
             val reason = event.values[1].asString

--- a/src/main/kotlin/dev/vxrp/bot/modals/NoticeOfDepartureTemplateModals.kt
+++ b/src/main/kotlin/dev/vxrp/bot/modals/NoticeOfDepartureTemplateModals.kt
@@ -2,12 +2,13 @@ package dev.vxrp.bot.modals
 
 import dev.minn.jda.ktx.interactions.components.TextInputBuilder
 import dev.vxrp.bot.noticeofdeparture.enums.ActionId
+import dev.vxrp.configuration.data.Config
 import dev.vxrp.configuration.data.Translation
 import net.dv8tion.jda.api.interactions.components.ActionRow
 import net.dv8tion.jda.api.interactions.components.text.TextInputStyle
 import net.dv8tion.jda.api.interactions.modals.Modal
 
-class NoticeOfDepartureTemplateModals(val translation: Translation) {
+class NoticeOfDepartureTemplateModals(val config: Config, val translation: Translation) {
     fun generalModal(): Modal {
         return Modal.create("notice_of_departure_general", translation.noticeOfDeparture.modalTitle).addComponents(
             ActionRow.of(
@@ -17,7 +18,8 @@ class NoticeOfDepartureTemplateModals(val translation: Translation) {
                     style = TextInputStyle.SHORT,
                     required = true,
                     requiredLength = 10..10,
-                    placeholder = translation.noticeOfDeparture.modalTimePlaceHolder).build()
+                    placeholder = translation.noticeOfDeparture.modalTimePlaceHolder
+                        .replace("%formatter%", config.settings.noticeOfDeparture.dateFormatting)).build()
             ),
             ActionRow.of(
                 TextInputBuilder(

--- a/src/main/kotlin/dev/vxrp/bot/noticeofdeparture/handler/NoticeOfDepartureCheckerHandler.kt
+++ b/src/main/kotlin/dev/vxrp/bot/noticeofdeparture/handler/NoticeOfDepartureCheckerHandler.kt
@@ -19,7 +19,7 @@ class NoticeOfDepartureCheckerHandler(val api: JDA, val config: Config, val tran
 
         for (id in idList) {
             val currentDate = LocalDate.now()
-            val formatter = DateTimeFormatter.ofPattern("dd.MM.yyyy")
+            val formatter = DateTimeFormatter.ofPattern(config.settings.noticeOfDeparture.dateFormatting)
             val beginDate = LocalDate.parse(NoticeOfDepartureTable().retrieveBeginDate(id)!!, formatter)
             val endDate = LocalDate.parse(NoticeOfDepartureTable().retrieveEndDate(id)!!, formatter)
 

--- a/src/main/kotlin/dev/vxrp/bot/noticeofdeparture/handler/NoticeOfDepartureMessageHandler.kt
+++ b/src/main/kotlin/dev/vxrp/bot/noticeofdeparture/handler/NoticeOfDepartureMessageHandler.kt
@@ -110,7 +110,7 @@ class NoticeOfDepartureMessageHandler(val api: JDA, val config: Config, val tran
         privateChannel.send("", listOf(embed)).queue()
     }
 
-    suspend fun sendNoticeMessage(reason: String, handler: String, userId: String, date: String) {
+    suspend fun sendNoticeMessage(reason: String, handlerId: String, userId: String, date: String) {
         val formatter = DateTimeFormatter.ofPattern("dd.MM.yyyy")
         val currentDate = LocalDate.now()
         val endDate = LocalDate.parse(date, formatter)
@@ -119,6 +119,7 @@ class NoticeOfDepartureMessageHandler(val api: JDA, val config: Config, val tran
         val discordEndDate = TimeFormat.DATE_LONG.atInstant(endDate.atStartOfDay(ZoneId.systemDefault()).toInstant()).toString()
         val relativeTime = TimeFormat.RELATIVE.atInstant(endDate.atStartOfDay(ZoneId.systemDefault()).toInstant()).toString()
 
+        val handler = api.retrieveUserById(handlerId).await()
         val user = api.retrieveUserById(userId).await()
 
         val embed = Embed {
@@ -129,7 +130,7 @@ class NoticeOfDepartureMessageHandler(val api: JDA, val config: Config, val tran
             )
             description = ColorTool().useCustomColorCodes(
                 translation.noticeOfDeparture.embedNoticeBody
-                    .replace("%user%", user.asMention)
+                    .replace("%user%", handler.asMention)
                     .replace("%current_date%", discordCurrentDate)
                     .replace("%end_date%", discordEndDate)
                     .replace("%relative%", relativeTime)
@@ -145,7 +146,7 @@ class NoticeOfDepartureMessageHandler(val api: JDA, val config: Config, val tran
             return
         }
 
-        NoticeOfDepartureTable().addToDatabase(userId, true, handler, channel.id, message.id, currentDate.format(formatter), endDate.format(formatter))
+        NoticeOfDepartureTable().addToDatabase(userId, true, handlerId, channel.id, message.id, currentDate.format(formatter), endDate.format(formatter))
     }
 
     suspend fun sendRevokedMessage(reason: String, userId: String, beginDate: String, endDate: String) {

--- a/src/main/kotlin/dev/vxrp/bot/noticeofdeparture/handler/NoticeOfDepartureMessageHandler.kt
+++ b/src/main/kotlin/dev/vxrp/bot/noticeofdeparture/handler/NoticeOfDepartureMessageHandler.kt
@@ -34,7 +34,7 @@ class NoticeOfDepartureMessageHandler(val api: JDA, val config: Config, val tran
     }
 
     suspend fun sendDecisionMessage(userId: String, date: String, reason: String) {
-        val formatter = DateTimeFormatter.ofPattern("dd.MM.yyyy")
+        val formatter = DateTimeFormatter.ofPattern(config.settings.noticeOfDeparture.dateFormatting)
         val currentDate = LocalDate.now()
         val endDate = LocalDate.parse(date, formatter)
 
@@ -73,7 +73,7 @@ class NoticeOfDepartureMessageHandler(val api: JDA, val config: Config, val tran
     }
 
     suspend fun sendAcceptedMessage(reason: String, userId: String, date: String) {
-        val formatter = DateTimeFormatter.ofPattern("dd.MM.yyyy")
+        val formatter = DateTimeFormatter.ofPattern(config.settings.noticeOfDeparture.dateFormatting)
         val currentDate = LocalDate.now()
         val endDate = LocalDate.parse(date, formatter)
 
@@ -112,7 +112,7 @@ class NoticeOfDepartureMessageHandler(val api: JDA, val config: Config, val tran
     }
 
     suspend fun sendNoticeMessage(reason: String, handlerId: String, userId: String, date: String) {
-        val formatter = DateTimeFormatter.ofPattern("dd.MM.yyyy")
+        val formatter = DateTimeFormatter.ofPattern(config.settings.noticeOfDeparture.dateFormatting)
         val currentDate = LocalDate.now()
         val endDate = LocalDate.parse(date, formatter)
 
@@ -151,7 +151,7 @@ class NoticeOfDepartureMessageHandler(val api: JDA, val config: Config, val tran
     }
 
     suspend fun sendRevokedMessage(reason: String, userId: String, beginDate: String, endDate: String) {
-        val formatter = DateTimeFormatter.ofPattern("dd.MM.yyyy")
+        val formatter = DateTimeFormatter.ofPattern(config.settings.noticeOfDeparture.dateFormatting)
         val currentDate = LocalDate.parse(beginDate, formatter)
         val endDate = LocalDate.parse(endDate, formatter)
 
@@ -174,7 +174,7 @@ class NoticeOfDepartureMessageHandler(val api: JDA, val config: Config, val tran
     }
 
     suspend fun sendEndedMessage(userId: String, beginDate: String, endDate: String) {
-        val formatter = DateTimeFormatter.ofPattern("dd.MM.yyyy")
+        val formatter = DateTimeFormatter.ofPattern(config.settings.noticeOfDeparture.dateFormatting)
         val currentDate = LocalDate.parse(beginDate, formatter)
         val endDate = LocalDate.parse(endDate, formatter)
 

--- a/src/main/kotlin/dev/vxrp/bot/noticeofdeparture/handler/NoticeOfDepartureMessageHandler.kt
+++ b/src/main/kotlin/dev/vxrp/bot/noticeofdeparture/handler/NoticeOfDepartureMessageHandler.kt
@@ -24,7 +24,8 @@ class NoticeOfDepartureMessageHandler(val api: JDA, val config: Config, val tran
     fun sendTemplate(channel: TextChannel) {
         val embed = Embed {
             title = ColorTool().useCustomColorCodes(translation.noticeOfDeparture.embedTemplateTitle)
-            description = ColorTool().useCustomColorCodes(translation.noticeOfDeparture.embedTemplateBody)
+            description = ColorTool().useCustomColorCodes(translation.noticeOfDeparture.embedTemplateBody
+                .replace("%formatter%", config.settings.noticeOfDeparture.dateFormatting))
         }
 
         channel.send("", listOf(embed)).setActionRow(

--- a/src/main/kotlin/dev/vxrp/configuration/data/Config.kt
+++ b/src/main/kotlin/dev/vxrp/configuration/data/Config.kt
@@ -115,6 +115,8 @@ data class ConfigVerify(
 @Serializable
 data class ConfigNoticeOfDeparture(
     val active: Boolean,
+    @SerialName("date_formatting")
+    val dateFormatting: String,
     @SerialName("decision_channel_id")
     val decisionChannel: String,
     @SerialName("notice_channel_id")

--- a/src/main/resources/SCPToolsBot/configs/config.yml
+++ b/src/main/resources/SCPToolsBot/configs/config.yml
@@ -111,6 +111,8 @@ verify:
 notice_of_departure:
   # Activates the notice of departure feature
   active: false
+  # The formatting that is used to format the notice of departure dates
+  date_formatting: "dd.MM.yyyy"
   # Which channel should the form be sent to, to be accepted by moderators?
   decision_channel_id: ""
   # Which channel should the notice messages be sent to?

--- a/src/main/resources/SCPToolsBot/configs/extra/updates.json
+++ b/src/main/resources/SCPToolsBot/configs/extra/updates.json
@@ -12,7 +12,7 @@
   },
 
   "configurationUpdate": {
-    "config": false,
+    "config": true,
     "statusSettings": false,
     "ticketSettings": false,
     "extra": {

--- a/src/main/resources/SCPToolsBot/lang/de_DE.yml
+++ b/src/main/resources/SCPToolsBot/lang/de_DE.yml
@@ -632,7 +632,7 @@ NOTICE_OF_DEPARTURE:
                         &filler&
                         **Benötigte Informationen**\n
                         Diese Informationen werden für deine Abmeldung benötigt.\n
-                        - Das Datum deiner Rückkehr. Bitte verwende dieses Format, andernfalls wird die Abmeldung nicht akzeptiert: **dd.MM.yyyy**\n
+                        - Das Datum deiner Rückkehr. Bitte verwende dieses Format, andernfalls wird die Abmeldung nicht akzeptiert: **%formatter%**\n
                         
                         - Eine kurze Erklärung, warum du eine Auszeit benötigen. Gehe nicht zu sehr ins Detail, nur so viel, dass es Sinn ergibt.\n
                         
@@ -641,12 +641,12 @@ NOTICE_OF_DEPARTURE:
 
   MODAL_TITLE: "Abmeldung stellen"
   MODAL_TIME_TITLE: "Wie lange bist du weg?"
-  MODAL_TIME_PLACEHOLDER: "wie lange, immer im format [dd.MM.yyyy]"
+  MODAL_TIME_PLACEHOLDER: "wie lange, immer im format [%formatter%]"
   MODAL_EXPLANATION_TITLE: "Erklärung"
   MODAL_EXPLANATION_PLACEHOLDER: "Wieso wirst du weg sein? [keine details]"
 
   EMBED_ENTER_VALID_DATE_TITLE: "Gib ein gültiges Datumsformat an"
-  EMBED_ENTER_VALID_DATE_BODY: "Du musst ein gültiges Datumsformat eingeben. Das akzeptierte Format ist: **dd.MM.yyyy**"
+  EMBED_ENTER_VALID_DATE_BODY: "Du musst ein gültiges Datumsformat eingeben. Das akzeptierte Format ist: **%formatter%**"
 
   EMBED_ENTER_FUTURE_DATE_TITLE: "Gib ein Datum in der Zukunft an"
   EMBED_ENTER_FUTURE_DATE_BODY: "Du musst ein Datum angeben das in der Zukunft liegt."

--- a/src/main/resources/SCPToolsBot/lang/en_US.yml
+++ b/src/main/resources/SCPToolsBot/lang/en_US.yml
@@ -630,7 +630,7 @@ NOTICE_OF_DEPARTURE:
                         &filler&
                         **Needed Information**\n
                         This information will be needed for your notice of departure.\n
-                        - The date you wish to come back. Please follow this format when entering or it will not be accepted: **dd.MM.yyyy**\n
+                        - The date you wish to come back. Please follow this format when entering or it will not be accepted: **%formatter%**\n
                         
                         - A short explanation on why you need some time off. Don't go into too much detail, just enough for it to make sense.\n
                         
@@ -639,12 +639,12 @@ NOTICE_OF_DEPARTURE:
 
   MODAL_TITLE: "File Notice of Departure"
   MODAL_TIME_TITLE: "Away time?"
-  MODAL_TIME_PLACEHOLDER: "How long will you be away [dd.MM.yyyy]"
+  MODAL_TIME_PLACEHOLDER: "How long will you be away [%formatter%]"
   MODAL_EXPLANATION_TITLE: "Explanation"
   MODAL_EXPLANATION_PLACEHOLDER: "Why are you going to be away [exclude details]"
 
   EMBED_ENTER_VALID_DATE_TITLE: "Enter a valid date format"
-  EMBED_ENTER_VALID_DATE_BODY: "You need to enter a valid date format to proceed. The accepted format is: **dd.MM.yyyy**"
+  EMBED_ENTER_VALID_DATE_BODY: "You need to enter a valid date format to proceed. The accepted format is: **%formatter%**"
 
   EMBED_ENTER_FUTURE_DATE_TITLE: "Enter a future date"
   EMBED_ENTER_FUTURE_DATE_BODY: "You need to enter a date in the future to proceed."


### PR DESCRIPTION
<!--
  Thank you for creating a PR. Please mark all required information with an 'x' e.g. '- [x]'
  If you have any questions, join the dc.

  NOTICE: If you are creating a PR for fixing an issue, please reference it. If it does not
  exist, please create it and then follow through with the PR.
-->
## Etiquette
- [x] Did you check the contribution guidelines?
- [x] Does this request not already exist in another form?
<!--
  What exactly did you change?
-->
## Changes
- [x] Bugfix
- [x] Feature
- [ ] Behavior Change
- [x] Configuration
- [ ] Other: ____
<!--
  How thoroughly did you test your changes?
-->
## Tested
- [x] Completely
- [ ] Mostly
- [ ] Partly
- [ ] Nothing
<!--
  Describe all of your changes and what they purpose is. If you added a new feature, explain
  why you want it implemented and how to use it.
-->
## Description

This brings a fix to a switch up of handler and issuer in notice of departures. In addition, there is a new feature that allows the user to configure a custom `DateTimeFormatter`, that will be used for the notice of departure feature only.

You will have to add this line to your config right under the notice of departure active value (as shown in the screenshot):
```yaml
  # The formatting that is used to format the notice of departure dates
  date_formatting: "dd.MM.yyyy"
```

![Image](https://github.com/user-attachments/assets/fc68a8b8-091c-4383-a056-92ed3eb486cd)

Also, all mentions of the formatter in the translation has been replaced by the %formatter% tag, which will adapt to the current configured formatter, loaded after every restart. So make sure to reset you language files.